### PR TITLE
Fixes an issue where for some reason floodgate could not detect a player

### DIFF
--- a/src/main/java/de/photon/anticheataddition/user/User.java
+++ b/src/main/java/de/photon/anticheataddition/user/User.java
@@ -77,7 +77,7 @@ public final class User implements Permissible
         USERS.put(player.getUniqueId(), this);
 
         final var floodgateApi = AntiCheatAddition.getInstance().getFloodgateApi();
-        if (floodgateApi != null && floodgateApi.isFloodgateId(player.getUniqueId())) {
+        if (floodgateApi != null && floodgateApi.isFloodgatePlayer(player.getUniqueId())) {
             FLOODGATE_USERS.add(this);
         }
 


### PR DESCRIPTION
Due to some floodgate/geyser settings AntiCheatAddition did not always detect Bedrock player. I changed it to isFloodgatePlayer(UUID) and now it detects Geyser players perfectly. Tested with the latest versions of Geyser and floodgate with the default Geyser configs and with my configs that had problems. 