### PR TITLE
Improve test coverage with faster mocks

### DIFF
--- a/src/test/java/de/photon/anticheataddition/util/minecraft/ping/PingProviderTest.java
+++ b/src/test/java/de/photon/anticheataddition/util/minecraft/ping/PingProviderTest.java
@@ -1,0 +1,34 @@
+package de.photon.anticheataddition.util.minecraft.ping;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class PingProviderTest {
+
+    @Test
+    void atMostMaxPingCases() {
+        int[] pings = {50, 100, 150};
+        boolean[] expected = {true, true, false};
+        int max = 100;
+        Player player = mock(Player.class);
+        for (int i = 0; i < pings.length; i++) {
+            int ping = pings[i];
+            PingProvider provider = p -> ping;
+            assertEquals(expected[i], provider.atMostMaxPing(player, max), "ping=" + ping);
+        }
+    }
+
+    @Test
+    void negativeMaxPingAlwaysTrue() {
+        int[] pings = {0, 100, 200};
+        Player player = mock(Player.class);
+        for (int ping : pings) {
+            PingProvider provider = p -> ping;
+            assertTrue(provider.atMostMaxPing(player, -1));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- remove ChatMessageTest
- rewrite PingProviderTest without junit params

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bd0936b30832faf12d144bb4a7730