### PR TITLE
Ensure ByteBuf released in BrandHider

### DIFF
--- a/src/main/java/de/photon/anticheataddition/modules/additions/BrandHider.java
+++ b/src/main/java/de/photon/anticheataddition/modules/additions/BrandHider.java
@@ -42,11 +42,16 @@ public final class BrandHider extends Module implements Listener
     private void updateBrand(final Player player)
     {
         final ByteBuf buf = Unpooled.buffer();
+        try
+        {
+            ByteBufUtil.writeString(buf, Placeholders.replacePlaceholders(this.brand, player));
 
-        ByteBufUtil.writeString(buf, Placeholders.replacePlaceholders(this.brand, player));
-
-        player.sendPluginMessage(AntiCheatAddition.getInstance(), MessageChannel.MC_BRAND_CHANNEL.getChannel().orElseThrow(), ByteBufUtil.toArray(buf));
-        buf.release();
+            player.sendPluginMessage(AntiCheatAddition.getInstance(), MessageChannel.MC_BRAND_CHANNEL.getChannel().orElseThrow(), ByteBufUtil.toArray(buf));
+        }
+        finally
+        {
+            buf.release();
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
- ensure ByteBuf in BrandHider.updateBrand is released via try/finally

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: The following artifacts could not be resolved: org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 (absent): Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f58a17f4832fbf4eb88feb5ff95b